### PR TITLE
Add byte model constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bower_components/
+*.swp

--- a/src/js/model/byte/byte.js
+++ b/src/js/model/byte/byte.js
@@ -1,0 +1,39 @@
+var AMPParse = AMPParse || {};
+
+AMPParse.buildByte = function (hexadecimal)
+{
+	// Defensive programming
+	if (typeof hexadecimal === "undefined" || typeof hexadecimal !== "string")
+	{
+		throw new ReferenceError("Provided parameter does not exist or is not a string");
+	}
+	if (hexadecimal.length < 2)
+	{
+		throw new RangeError("The provided hex is too short to contain a byte.");
+	}
+
+	// Snag the relevant bytes and build return value object
+	var byteChars = hexadecimal.substring(0, 2);
+	var rawValue = parseInt(byteChars, 16);
+	var returnValue = {
+		type: "Byte",
+		value: rawValue,
+		binaryValue: ""
+	};
+
+	// Make the binary representation and append prefix
+	for (var i = 0; i < 8; i++)
+	{
+		returnValue.binaryValue = ( rawValue & 1 ).toString() + returnValue.binaryValue;
+		rawValue = rawValue >>> 1;
+	}
+
+	returnValue.binaryValue = "0b" + returnValue.binaryValue;
+
+	// Return object according to spec
+	return {
+		returnValue: returnValue,
+		nibblesConsumed: 2,
+		trailingHex: hexadecimal.substring(2)
+	};
+}

--- a/src/js/model/byte/test-byte-model.html
+++ b/src/js/model/byte/test-byte-model.html
@@ -1,0 +1,47 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+		<script src="../../../../bower_components/web-component-tester/browser.js"></script>
+		<link rel="import" href="../../../../bower_components/webcomponentsjs/webcomponents-lite.js">
+
+		<script src="byte.js"></script>
+	</head>
+	<body>
+		<script>
+
+suite("Byte model constructor", function()
+{
+	var byteHex;
+	var returnedObj;
+
+	suiteSetup(function()
+	{
+		bytehex = "1FABCDE";
+		returnedObj = AMPParse.buildByte(bytehex);
+	});
+
+	test("returns the correct value", function()
+	{
+		expect(returnedObj.returnValue.value).to.be.a("number").and.equal(31);
+		expect(returnedObj.returnValue.binaryValue).to.be.a("string").and.equal("0b00011111");
+	});
+
+	test("returns correct trailing hexadecimal", function()
+	{
+		expect(returnedObj.trailingHex).to.equal("ABCDE");
+	});
+
+	test("throws ReferenceError on bad parameters", function()
+	{
+		expect(function() { AMPParse.buildByte(); }).to.throw(ReferenceError);
+		expect(function() { AMPParse.buildByte(25); }).to.throw(ReferenceError);
+	});
+
+	test("throws RangeError on short inputs", function()
+	{
+		expect(function() { AMPParse.buildByte("A"); }).to.throw(RangeError);
+	});
+});
+		</script>
+	</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -8,7 +8,8 @@
 <body>
 	<script>
 WCT.loadSuites([
-		'sauce-test.html'
+		'sauce-test.html',
+		'../src/js/model/byte/test-byte-model.html'
 ]);
 	</script>
 </body>


### PR DESCRIPTION
I added the byte.js file along with a unit test for it. Byte.js adds the `AMPParse.buildByte()` function to consume 2 nibbles of the hexadecimal and construct a JSON byte object according to the spec in the wiki.