### PR TITLE
Clean up byte testing

### DIFF
--- a/src/js/model/byte/byte.js
+++ b/src/js/model/byte/byte.js
@@ -3,13 +3,13 @@ var AMPParse = AMPParse || {};
 AMPParse.buildByte = function (hexadecimal)
 {
 	// Defensive programming
-	if (typeof hexadecimal === "undefined" || typeof hexadecimal !== "string")
+	if (typeof hexadecimal !== "string")
 	{
 		throw new ReferenceError("Provided parameter does not exist or is not a string");
 	}
-	if (hexadecimal.length < 2)
+	if (hexadecimal.length < 2 || hexadecimal.length % 2 !== 0)
 	{
-		throw new RangeError("The provided hex is too short to contain a byte.");
+		throw new RangeError("The provided hex is too short to contain a byte or is misaligned.");
 	}
 
 	// Snag the relevant bytes and build return value object

--- a/src/js/model/byte/test-byte-model.html
+++ b/src/js/model/byte/test-byte-model.html
@@ -1,8 +1,8 @@
 <html>
 	<head>
 		<meta charset="utf-8">
+		<script src="../../../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../../bower_components/web-component-tester/browser.js"></script>
-		<link rel="import" href="../../../../bower_components/webcomponentsjs/webcomponents-lite.js">
 
 		<script src="byte.js"></script>
 	</head>
@@ -16,7 +16,7 @@ suite("Byte model constructor", function()
 
 	suiteSetup(function()
 	{
-		bytehex = "1FABCDE";
+		bytehex = "1FABCDEF";
 		returnedObj = AMPParse.buildByte(bytehex);
 	});
 
@@ -28,7 +28,7 @@ suite("Byte model constructor", function()
 
 	test("returns correct trailing hexadecimal", function()
 	{
-		expect(returnedObj.trailingHex).to.equal("ABCDE");
+		expect(returnedObj.trailingHex).to.equal("ABCDEF");
 	});
 
 	test("throws ReferenceError on bad parameters", function()
@@ -40,6 +40,11 @@ suite("Byte model constructor", function()
 	test("throws RangeError on short inputs", function()
 	{
 		expect(function() { AMPParse.buildByte("A"); }).to.throw(RangeError);
+	});
+
+	test("throws RangeError on inputs with an odd number of characters", function()
+	{
+		expect(function() { AMPParse.buildByte("ABB"); }).to.throw(RangeError);
 	});
 });
 		</script>


### PR DESCRIPTION
 * Add checks to make sure there are an even number of nibbles
 * Remove redundant "input is undefined" check because string typecheck satisfies the same test